### PR TITLE
docs: fix simple typo, representaion -> representation

### DIFF
--- a/slre.c
+++ b/slre.c
@@ -126,7 +126,7 @@ static int match_op(const unsigned char *re, const unsigned char *s,
         case 'v': FAIL_IF(*s != '\v', SLRE_NO_MATCH); result++; break;
 
         case 'x':
-          /* Match byte, \xHH where HH is hexadecimal byte representaion */
+          /* Match byte, \xHH where HH is hexadecimal byte representation */
           FAIL_IF(hextoi(re + 2) != *s, SLRE_NO_MATCH);
           result++;
           break;


### PR DESCRIPTION
There is a small typo in slre.c.

Should read `representation` rather than `representaion`.

